### PR TITLE
Enable precompilation (no more segfaults)

### DIFF
--- a/src/JAC.jl
+++ b/src/JAC.jl
@@ -169,6 +169,12 @@ include("jac-document.jl")
 include("jac-test.jl")
 include("jac-tools.jl")
 
+function __init__()
+    # The following variables need to be initialized at runtime to enable precompilation
+    global JAC_SUMMARY_IOSTREAM = stdout
+    global JAC_TEST_IOSTREAM    = stdout
+end
+
 println("\nWelcome to JAC:  A fresh computational approach to atomic structures, processes, casacdes and time evolutions [(C) Copyright by Stephan Fritzsche, Jena (2019)].")
 
 end

--- a/src/jac-constants.jl
+++ b/src/jac-constants.jl
@@ -75,8 +75,10 @@ JAC_CROSS_SECTION_UNIT      = "barn"
 JAC_RATE_UNIT               = "1/s"
 JAC_TIME_UNIT               = "sec"
 
-JAC_SUMMARY_IOSTREAM        = stdout
-JAC_TEST_IOSTREAM           = stdout
+# JAC_SUMMARY_IOSTREAM and JAC_TEST_IOSTREAM are initialized at runtime (see JAC.__init__())
+# JAC_SUMMARY_IOSTREAM        = stdout
+# JAC_TEST_IOSTREAM           = stdout
+
 JAC_PRINT_SUMMARY           = false
 JAC_PRINT_TEST              = false
 


### PR DESCRIPTION
This initializes `JAC_SUMMARY_IOSTREAM` and `JAC_TEST_IOSTREAM` at runtime to enable precompilation (and thus get rid of the segfaults).