### PR TITLE
Allow failures on Julia nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ julia:
   - 1.1
   - nightly
 
+matrix:
+  allow_failures:
+    - julia: nightly
+
 notifications:
   email: false
 
@@ -17,9 +21,4 @@ addons:
     packages:
     - gfortran
 
-after_success:
-  - julia -e 'using Pkg;
-      cd(Pkg.dir("JAC"));
-      Pkg.add("Coverage");
-      using Coverage;
-      Codecov.submit(process_folder());'
+codecov: true


### PR DESCRIPTION
The current failure of the Travis build is due to a bug on the current Julia master: https://github.com/JuliaLang/julia/issues/31488

This PR changes the Travis configuration to allow failures when testing with the Julia nightly version. It also simplifies the config file.