### PR TITLE
Delete REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,9 +1,0 @@
-julia 1.0
-Interact
-SpecialFunctions
-FortranFiles
-GaussQuadrature
-GSL
-QuadGK
-MacroTools
-RecipesBase


### PR DESCRIPTION
As of today, the REQUIRE file is no longer needed to register a package for Julia ≥ 0.7: https://discourse.julialang.org/t/switching-package-registration-systems-on-monday/22677

Since this package is only compatible with Julia ≥ 1.0, the REQUIRE file can be deleted.