### PR TITLE
Update rabs_rcfp.f90

### DIFF
--- a/deps/ratip2013-angular-coefficients/rabs_rcfp.f90
+++ b/deps/ratip2013-angular-coefficients/rabs_rcfp.f90
@@ -2342,6 +2342,7 @@ contains
       integer, dimension(9), parameter :: no_max = (/2,0,5,0,11,0,25,0,63/)
       integer                          :: p_min, p_max, run
       !
+      fail = .false.
       if (j <= 9) then
          p_min = no_min(j);   p_max = no_max(j)
          if (rabs_use_stop         .and.  &


### PR DESCRIPTION
In my case, the rcfp_get_term_number returns fail=.true. even though the input is valid. This stops the whole program. The "fail" boolean variable is not initialized to .false. at the beginning of the function, thus, the function may return .true. even when the "value" is properly set in one of the "ifs". This issue may be system/compiler-dependent, depending on the internal initialization of the variable. A simple solution is proposed to add fail = .false. initialization on line 2345.