### PR TITLE
Remove deps directory

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,6 +1,0 @@
-isdir("bin") || mkdir("bin")
-cd("ratip2013-angular-coefficients")
-run(`make`)
-##x cd("../grasp2013-nucpot")
-##x run(`make`)
-cd("..")

--- a/deps/build.log
+++ b/deps/build.log
@@ -1,4 +1,0 @@
-gfortran -O3 -shared -fPIC -o jac_anco.so jac_anco.f90  rabs_anco.f90  rabs_angular.f90  rabs_constant.f90  rabs_csl.f90  \
-	rabs_determinant.f90  rabs_dirac_orbital.f90  rabs_file_handling.f90  rabs_functions_math.f90  \
-	rabs_functions_string.f90  rabs_grasp92.f90  rabs_io_dialog.f90  rabs_mcp_adaptation.f90  rabs_mcp_grasp92.f  \
-	rabs_mcp_mct.f90  rabs_naglib.f90  rabs_njgraf.f  rabs_nucleus.f90  rabs_rcfp.f90  rabs_recoupling.f90 -o ../bin/libanco-ratip2013.so


### PR DESCRIPTION
Currently, building the package errors because it tries to compile the ANCO library which was removed:
```julia
pkg> add https://github.com/OpenJAC/JAC.jl
    Updating git-repo `https://github.com/OpenJAC/JAC.jl`
    Updating registry at `~/.julia/registries/General`
    Updating git-repo `https://github.com/JuliaRegistries/General.git`
   Resolving package versions...
[...]
    Building JAC → `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/8f56a3362d623e340ac3c6801d3f9e972a87ba7a/build.log`
ERROR: Error building `JAC`:
ERROR: LoadError: IOError: cd("ratip2013-angular-coefficients"): no such file or directory (ENOENT)
Stacktrace:
[...]
```
This PR removes the `deps/build.jl` file which fixes the error during installation of the package. The `deps/builds.log` file is removed as well, since it is not supposed to be here anyway.